### PR TITLE
Implement loan deletion functionality with confirmation prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <title>Tredgate Loan</title>
   </head>
   <body>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import type { LoanApplication } from './types/loan'
-import { getLoans, updateLoanStatus, autoDecideLoan } from './services/loanService'
+import { getLoans, updateLoanStatus, autoDecideLoan, deleteLoan } from './services/loanService'
 import LoanForm from './components/LoanForm.vue'
 import LoanList from './components/LoanList.vue'
 import LoanSummary from './components/LoanSummary.vue'
@@ -27,6 +27,11 @@ function handleAutoDecide(id: string) {
   refreshLoans()
 }
 
+function handleDelete(id: string) {
+  deleteLoan(id)
+  refreshLoans()
+}
+
 onMounted(() => {
   refreshLoans()
 })
@@ -49,6 +54,7 @@ onMounted(() => {
         @approve="handleApprove"
         @reject="handleReject"
         @auto-decide="handleAutoDecide"
+        @delete="handleDelete"
       />
     </main>
   </div>

--- a/src/components/ConfirmModal.vue
+++ b/src/components/ConfirmModal.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+defineProps<{
+  isOpen: boolean
+  title: string
+  message: string
+}>()
+
+const emit = defineEmits<{
+  confirm: []
+  cancel: []
+}>()
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div v-if="isOpen" class="modal-overlay" @click="emit('cancel')">
+        <div class="modal-content" @click.stop>
+          <div class="modal-header">
+            <h3>{{ title }}</h3>
+          </div>
+          <div class="modal-body">
+            <p>{{ message }}</p>
+          </div>
+          <div class="modal-footer">
+            <button class="ghost-btn" @click="emit('cancel')">
+              Cancel
+            </button>
+            <button class="danger" @click="emit('confirm')">
+              Delete
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background-color: var(--card-background);
+  border-radius: var(--border-radius);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  width: 90%;
+  max-width: 500px;
+  overflow: hidden;
+}
+
+.modal-header {
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.modal-body {
+  padding: 1.5rem;
+}
+
+.modal-body p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.modal-footer {
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--border-color);
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.ghost-btn {
+  background-color: transparent;
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  padding: 0.5rem 1.5rem;
+}
+
+.ghost-btn:hover {
+  background-color: #f8f9fa;
+}
+
+.modal-footer button.danger {
+  padding: 0.5rem 1.5rem;
+}
+
+/* Transition animations */
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-active .modal-content,
+.modal-leave-active .modal-content {
+  transition: transform 0.2s ease;
+}
+
+.modal-enter-from .modal-content,
+.modal-leave-to .modal-content {
+  transform: scale(0.95);
+}
+</style>

--- a/src/components/LoanList.vue
+++ b/src/components/LoanList.vue
@@ -10,7 +10,14 @@ const emit = defineEmits<{
   approve: [id: string]
   reject: [id: string]
   autoDecide: [id: string]
+  delete: [id: string]
 }>()
+
+function handleDelete(id: string, applicantName: string) {
+  if (confirm(`Are you sure you want to delete the loan application for ${applicantName}?`)) {
+    emit('delete', id)
+  }
+}
 
 function formatCurrency(value: number): string {
   return new Intl.NumberFormat('en-US', {
@@ -93,6 +100,13 @@ function formatDate(isoDate: string): string {
                 title="Auto-decide"
               >
                 ⚡
+              </button>
+              <button
+                class="action-btn danger"
+                @click="handleDelete(loan.id, loan.applicantName)"
+                title="Delete"
+              >
+                🗑️
               </button>
               <span v-if="loan.status !== 'pending'" class="no-actions">—</span>
             </td>

--- a/src/components/LoanList.vue
+++ b/src/components/LoanList.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import type { LoanApplication } from '../types/loan'
 import { calculateMonthlyPayment } from '../services/loanService'
+import ConfirmModal from './ConfirmModal.vue'
 
 defineProps<{
   loans: LoanApplication[]
@@ -13,10 +15,25 @@ const emit = defineEmits<{
   delete: [id: string]
 }>()
 
+const isModalOpen = ref(false)
+const selectedLoan = ref<{ id: string; name: string } | null>(null)
+
 function handleDelete(id: string, applicantName: string) {
-  if (confirm(`Are you sure you want to delete the loan application for ${applicantName}?`)) {
-    emit('delete', id)
+  selectedLoan.value = { id, name: applicantName }
+  isModalOpen.value = true
+}
+
+function confirmDelete() {
+  if (selectedLoan.value) {
+    emit('delete', selectedLoan.value.id)
   }
+  isModalOpen.value = false
+  selectedLoan.value = null
+}
+
+function cancelDelete() {
+  isModalOpen.value = false
+  selectedLoan.value = null
 }
 
 function formatCurrency(value: number): string {
@@ -102,11 +119,11 @@ function formatDate(isoDate: string): string {
                 ⚡
               </button>
               <button
-                class="action-btn danger"
+                class="action-btn delete-btn"
                 @click="handleDelete(loan.id, loan.applicantName)"
                 title="Delete"
               >
-                🗑️
+                <span class="material-symbols-outlined">delete</span>
               </button>
               <span v-if="loan.status !== 'pending'" class="no-actions">—</span>
             </td>
@@ -114,6 +131,14 @@ function formatDate(isoDate: string): string {
         </tbody>
       </table>
     </div>
+
+    <ConfirmModal
+      :is-open="isModalOpen"
+      title="Delete Loan Application"
+      :message="`Are you sure you want to delete the loan application for ${selectedLoan?.name}? This action cannot be undone.`"
+      @confirm="confirmDelete"
+      @cancel="cancelDelete"
+    />
   </div>
 </template>
 
@@ -146,6 +171,26 @@ function formatDate(isoDate: string): string {
 
 .action-btn:last-child {
   margin-right: 0;
+}
+
+.delete-btn {
+  background-color: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+}
+
+.delete-btn:hover {
+  background-color: #f8f9fa;
+  color: var(--danger-color);
+  border-color: var(--danger-color);
+}
+
+.delete-btn .material-symbols-outlined {
+  font-size: 1.25rem;
 }
 
 .no-actions {

--- a/src/services/loanService.ts
+++ b/src/services/loanService.ts
@@ -116,3 +116,18 @@ export function autoDecideLoan(id: string): void {
 
   saveLoans(loans)
 }
+
+/**
+ * Delete a loan application by ID
+ */
+export function deleteLoan(id: string): void {
+  const loans = getLoans()
+  const loanIndex = loans.findIndex(loan => loan.id === id)
+  
+  if (loanIndex === -1) {
+    throw new Error(`Loan with id ${id} not found`)
+  }
+
+  loans.splice(loanIndex, 1)
+  saveLoans(loans)
+}

--- a/tests/loanService.test.ts
+++ b/tests/loanService.test.ts
@@ -5,7 +5,8 @@ import {
   createLoanApplication,
   updateLoanStatus,
   calculateMonthlyPayment,
-  autoDecideLoan
+  autoDecideLoan,
+  deleteLoan
 } from '../src/services/loanService'
 import type { LoanApplication } from '../src/types/loan'
 
@@ -325,6 +326,88 @@ describe('loanService', () => {
       expect(() => autoDecideLoan('non-existent')).toThrow(
         'Loan with id non-existent not found'
       )
+    })
+  })
+
+  describe('deleteLoan', () => {
+    it('successfully deletes an existing loan', () => {
+      const loan1: LoanApplication = {
+        id: 'loan-1',
+        applicantName: 'John Doe',
+        amount: 50000,
+        termMonths: 24,
+        interestRate: 0.08,
+        status: 'pending',
+        createdAt: '2024-01-01T00:00:00.000Z'
+      }
+      const loan2: LoanApplication = {
+        id: 'loan-2',
+        applicantName: 'Jane Smith',
+        amount: 75000,
+        termMonths: 36,
+        interestRate: 0.06,
+        status: 'approved',
+        createdAt: '2024-02-01T00:00:00.000Z'
+      }
+      saveLoans([loan1, loan2])
+
+      deleteLoan('loan-1')
+
+      const loans = getLoans()
+      expect(loans).toHaveLength(1)
+      expect(loans[0]?.id).toBe('loan-2')
+    })
+
+    it('throws error when loan ID is not found', () => {
+      const loan: LoanApplication = {
+        id: 'existing-loan',
+        applicantName: 'Test User',
+        amount: 10000,
+        termMonths: 12,
+        interestRate: 0.05,
+        status: 'pending',
+        createdAt: '2024-01-01T00:00:00.000Z'
+      }
+      saveLoans([loan])
+
+      expect(() => deleteLoan('non-existent-id')).toThrow(
+        'Loan with id non-existent-id not found'
+      )
+    })
+
+    it('updates localStorage correctly after deletion', () => {
+      const loan1: LoanApplication = {
+        id: 'loan-to-delete',
+        applicantName: 'Delete Me',
+        amount: 30000,
+        termMonths: 18,
+        interestRate: 0.07,
+        status: 'pending',
+        createdAt: '2024-03-01T00:00:00.000Z'
+      }
+      const loan2: LoanApplication = {
+        id: 'loan-to-keep',
+        applicantName: 'Keep Me',
+        amount: 40000,
+        termMonths: 24,
+        interestRate: 0.06,
+        status: 'approved',
+        createdAt: '2024-04-01T00:00:00.000Z'
+      }
+      saveLoans([loan1, loan2])
+
+      deleteLoan('loan-to-delete')
+
+      // Verify localStorage was called with the updated array
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'tredgate_loans',
+        JSON.stringify([loan2])
+      )
+
+      // Verify the loan was actually removed from storage
+      const storedLoans = getLoans()
+      expect(storedLoans).toHaveLength(1)
+      expect(storedLoans[0]?.id).toBe('loan-to-keep')
     })
   })
 })


### PR DESCRIPTION
This pull request adds the ability to delete loan applications from the app. The main changes include updating the UI to provide a delete button for each loan, handling user confirmation before deletion, and implementing the deletion logic in the service layer.

**Loan Deletion Feature:**

* Added a `deleteLoan` function to `loanService.ts` to remove a loan application by ID, including error handling if the loan is not found.
* Updated `App.vue` to import `deleteLoan`, define a `handleDelete` method, and wire up the method to refresh the loan list after deletion. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L4-R4) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R30-R34)
* Modified the `LoanList.vue` component to emit a `delete` event, show a delete button (🗑️) for each loan, and prompt the user for confirmation before deletion. [[1]](diffhunk://#diff-1352f3663cdd969ee28a168dcb23242a136ad4e7e564e578c78a432917255f8cR13-R21) [[2]](diffhunk://#diff-1352f3663cdd969ee28a168dcb23242a136ad4e7e564e578c78a432917255f8cR104-R110)
* Connected the new delete event from `LoanList.vue` to the handler in `App.vue`.